### PR TITLE
Added SplittableRandom to ensure reproducibility with given seed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
     	<groupId>se.lth.immun</groupId>
     	<artifactId>MzML</artifactId>
-    	<version>1.3.4</version>
+    	<version>1.3.5</version>
     </dependency>
     <dependency>
     	<groupId>se.lth.immun</groupId>

--- a/src/main/scala/se/lth/immun/Bootstrap.scala
+++ b/src/main/scala/se/lth/immun/Bootstrap.scala
@@ -1,18 +1,21 @@
 package se.lth.immun
 
-import scala.util.Random
+import java.util.SplittableRandom
 
-object Bootstrap {
+class SplittableBootstrap(
+		val rng:SplittableRandom,
+		val bufferOption:Option[Array[Array[Array[Int]]]] = None
+) {
 	val bufferLen = 999
 	val maxVectorLen = 99
-	val buffer = {
+	val buffer = bufferOption getOrElse {
 		val a = new Array[Array[Array[Int]]](bufferLen)
 		for (i <- 0 until bufferLen) {
 			a(i) = new Array[Array[Int]](maxVectorLen)
 			for (j <- 0 until maxVectorLen) {
 				a(i)(j) = new Array[Int](j)
 				for (k <- 0 until j)
-					a(i)(j)(k) = Random.nextInt(j)
+					a(i)(j)(k) = rng.nextInt(j)
 			}
 		}
 		a
@@ -20,7 +23,10 @@ object Bootstrap {
 	var count = 0
 	
 	
-	def set(k:Int, nBoot:Int):Seq[Int] = set(k, k, nBoot)
+	def split():SplittableBootstrap = {
+		val rng_splitted = rng.split()
+		new SplittableBootstrap(rng_splitted, Some(buffer))
+	}
 	
 	def set(k:Int, n:Int, nBoot:Int):Seq[Int] = 
 		if (k<=n && n < maxVectorLen && nBoot < bufferLen) {
@@ -30,96 +36,8 @@ object Bootstrap {
 			else
 				buffer(count)(n).take(k)
 		} else 
-			(0 until k).map(_ => Random.nextInt(n))
+			(0 until k).map(_ => rng.nextInt(n))
 	
-	val table2total = 4
-	val table2 = Array(
-		Array(2,0,1),
-		Array(1,1,2),
-		Array(0,2,1)
-	)
-	
-	val table3total = 27
-	val table3 = Array(
-		Array(3,0,0,1),
-		Array(2,1,0,3),
-		Array(2,0,1,3),
-		
-		Array(0,3,0,1),
-		Array(1,2,0,3),
-		Array(0,2,1,3),
-		
-		Array(0,0,3,1),
-		Array(1,0,2,3),
-		Array(0,1,2,3),
-		
-		Array(1,1,1,6)
-	)
-	
-	
-	def weightedAverage(xs:Seq[Double], ws:Seq[Double], nBoot:Int, maxBootSize:Int):(Double, Double) = {
-		val l = xs.length
-		val wXs = new Array[Double](l)
-		for (i <- 0 until l)
-			wXs(i) = ws(i) * xs(i)
-		
-		if (l > 3)
-			bootstrapWeightedAverage(wXs, ws, nBoot, maxBootSize)
-		else if (l == 2)
-			weightedAverageFromTable(Bootstrap.table2, wXs, ws)
-		else if (l == 3) 
-			weightedAverageFromTable(Bootstrap.table3, wXs, ws)
-		else
-			throw new Exception("This should never happen!")
-	}
-	
-	def weightedAverageFromTable(
-			tab:Array[Array[Int]], 
-			wXs:Seq[Double], 
-			ws:Seq[Double]
-	):(Double, Double) = {
-		val tl = tab.length
-		val ys = new Array[Double](tl)
-		val ks = new Array[Int](tl)
-		var sumYk = 0.0
-		var sumK = 0
-		var i = 0
-		while (i < tl) {
-			val row = tab(i)
-			val k = row.last
-			val y = weightedAverageTable(wXs, ws, row)
-			ys(i) = y
-			ks(i) = k
-			sumYk += y * k
-			sumK += k
-			i += 1
-		}
-		val avgY = sumYk / sumK
-		var err = 0.0
-		i = 0
-		while (i < tl) {
-			val residual = avgY - ys(i)
-			err += residual * residual * ks(i)
-			i += 1
-		}
-		(
-			avgY,
-			math.sqrt(err / (sumK-1))
-		)
-	}
-	
-	def weightedAverageTable(wXs:Seq[Double], ws:Seq[Double], row:Array[Int]):Double = {
-		var m = 0.0
-		var norm = 0.0
-		var j = 0
-		while (j < row.length - 1) {
-			val k = row(j)
-			m += wXs(j)*k
-			norm += ws(j)*k
-			j += 1
-		}
-		m / norm
-	}
 	
 	def bootstrapWeightedAverage(
 			wXs:Seq[Double], 
@@ -132,7 +50,7 @@ object Bootstrap {
 		var i = 0
 		var sumY = 0.0
 		while (i < nBoot) {
-			val y = weightedAverage(wXs, ws, Bootstrap.set(math.min(maxBootSize, l), l, nBoot))
+			val y = weightedAverage(wXs, ws, set(math.min(maxBootSize, l), l, nBoot))
 			ys(i) = y
 			sumY += y
 			i += 1

--- a/src/main/scala/se/lth/immun/Cluster.scala
+++ b/src/main/scala/se/lth/immun/Cluster.scala
@@ -3,7 +3,6 @@ package se.lth.immun
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.HashMap
 
-
 import se.lth.immun.chem.Peptide
 import se.lth.immun.chem.Constants
 import se.lth.immun.chem.IsotopeDistribution
@@ -79,16 +78,15 @@ class Cluster(
 	val intensities = hills.map(_.total.intensity)
 	val apexIntensities = hills.map(_.apex.intensity)
 	
-	
-	
 	def deconvolve(
+			bootstrap:SplittableBootstrap,
 			inds:Seq[Int] = 0 until hills.length
 	):List[IsotopePattern] = { 
 		if (inds.map(hills).exists(h => params.closeToDebug(h.total.centerMz)))
 			{ val k = 1 }
 		getBestPattern(inds) match {
 			case Some((ip, indsLeft)) =>
-				IsotopePattern(ip.inds.map(hills), ip.offset, ip.mostAbundNbr - ip.offset, ip.z, ip.averagineCorr) :: deconvolve(indsLeft)
+				IsotopePattern(ip.inds.map(hills), ip.offset, ip.mostAbundNbr - ip.offset, ip.z, ip.averagineCorr, bootstrap) :: deconvolve(bootstrap, indsLeft)
 			case None =>
 				Nil
 		}

--- a/src/main/scala/se/lth/immun/Dinosaur.scala
+++ b/src/main/scala/se/lth/immun/Dinosaur.scala
@@ -22,18 +22,18 @@ object Dinosaur extends CLIApp {
 	def main(args:Array[String]):Unit = {
 		
 		var properties = new Properties
-    	properties.load(this.getClass.getResourceAsStream("/pom.properties"))
-    	val name 		= properties.getProperty("pom.artifactId")
-    	val version 	= properties.getProperty("pom.version")
-    	val buildTime	= properties.getProperty("build.time")
-    	
-    	val params = new DinosaurParams(name, version)
-    	
+		properties.load(this.getClass.getResourceAsStream("/pom.properties"))
+		val name 		= properties.getProperty("pom.artifactId")
+ 		val version 	= properties.getProperty("pom.version")
+		val buildTime	= properties.getProperty("build.time")
+			
+		val params = new DinosaurParams(name, version)
+			
 		params.startTime 	= System.currentTimeMillis
 		
 		failOnError(parseArgs(name, version, args, params, List("mzML"), None))
-    	failOnError(parseParams(params.adv, params.advParams.value))
-    	
+		failOnError(parseParams(params.adv, params.advParams.value))
+			
 		if (params.advHelp) {
 			println(usage(name, version, args, params.adv, List("mzML"), None))
 			System.exit(0)
@@ -43,9 +43,9 @@ object Dinosaur extends CLIApp {
 		val (outDir, outName) = params.outBase
 		
 		println(name + " "+version + "    built:"+buildTime)
-    	println("  mzML file: " + params.mzML.value)
-    	println("    out dir: " + outDir)
-    	println("   out name: " + outName)
+		println("  mzML file: " + params.mzML.value)
+		println("    out dir: " + outDir)
+		println("   out name: " + outName)
 		println()
 		
 		params.reportRandom = 

--- a/src/main/scala/se/lth/immun/DinosaurParams.scala
+++ b/src/main/scala/se/lth/immun/DinosaurParams.scala
@@ -22,6 +22,7 @@ class DinosaurParams(val name:String, val version:String) extends Params {
 	val writeQuantML	= false		## "set to output mzQuantML file" 
 	val outDir			= ""		## "output directory (by default same as input mzML)"
 	val outName			= ""		## "basename for output files (by default same as input mzML)"
+	val seed		= -1L		## "seed to use for bootstrapping of mass calibration (<0 means random)"
 	
 	val nReport			= 10		## "number of random assay to export control figure for"
 	val reportSeed		= -1L		## "seed to use for report assay selection (<0 means random)"

--- a/src/main/scala/se/lth/immun/Hill.scala
+++ b/src/main/scala/se/lth/immun/Hill.scala
@@ -180,10 +180,10 @@ class Hill(
 	
 	
 	
-	def calcAverages(implicit params:DinosaurParams):Hill = {
+	def calcAverages(bootstrap:SplittableBootstrap)(implicit params:DinosaurParams):Hill = {
 		val totalIntensity = rawIntensity.sum
 			
-		val (tMz, tMzError) = calcTotalMz
+		val (tMz, tMzError) = calcTotalMz(bootstrap)
 		val totalMinMz = tMz - maxMzWidth/2 //minMz.min
 		val totalMaxMz = tMz + maxMzWidth/2 //maxMz.max
 		total = HillSummary(totalMinMz, totalMaxMz, totalIntensity, tMz, tMzError)
@@ -192,12 +192,12 @@ class Hill(
 	
 	
 	
-	def calcTotalMz(implicit params:DinosaurParams):(Double, Double) = {
+	def calcTotalMz(bootstrap:SplittableBootstrap)(implicit params:DinosaurParams):(Double, Double) = {
 		val weightedMz = new Array[Double](length)
 		for (i <- 0 until length)
 			weightedMz(i) = rawIntensity(i) * centerMz(i)
 		
-		Bootstrap.bootstrapWeightedAverage(weightedMz, rawIntensity, params.adv.hillNBoots, params.adv.maxBootSize)
+		bootstrap.bootstrapWeightedAverage(weightedMz, rawIntensity, params.adv.hillNBoots, params.adv.maxBootSize)
 	}
 	
 		

--- a/src/main/scala/se/lth/immun/HillBuilder.scala
+++ b/src/main/scala/se/lth/immun/HillBuilder.scala
@@ -82,7 +82,8 @@ class HillBatch(
 
 
 
-class HillBuilderActorParallel(val params:DinosaurParams) extends Actor {
+// we only need a single Bootstrap object, since the part that uses it is non-parallel
+class HillBuilderActorParallel(val bootstrap:SplittableBootstrap, val params:DinosaurParams) extends Actor {
 	
 	implicit val pd = params
 	
@@ -213,7 +214,7 @@ class HillBuilderActorParallel(val params:DinosaurParams) extends Actor {
 			val tt2 = System.currentTimeMillis
 			val filtered = decomposed.filter(_.length >= params.adv.hillMinLength)
 			val tt3 = System.currentTimeMillis
-			val averaged = filtered.map(_.calcAverages)
+			val averaged = filtered.map(h => h.calcAverages(bootstrap))
 			val tt4 = System.currentTimeMillis
 			
 			if (params.verbose)

--- a/src/main/scala/se/lth/immun/IsotopePattern.scala
+++ b/src/main/scala/se/lth/immun/IsotopePattern.scala
@@ -7,7 +7,8 @@ case class IsotopePattern(
 		val isotopeOffset:Int, 
 		val mostAbundNbr:Int, 
 		val z:Int, 
-		val averagineCorr:Double
+		val averagineCorr:Double,
+		val bootstrap:SplittableBootstrap
 )(implicit params:DinosaurParams) {
 	
 	def length 		= hills.length
@@ -38,7 +39,7 @@ case class IsotopePattern(
 			for (i <- 0 until nBoot) 
 			yield averageMass(
 					rawIntensities,
-					Bootstrap.set(math.min(params.adv.maxBootSize, n), n, nBoot),
+					bootstrap.set(math.min(params.adv.maxBootSize, n), n, nBoot),
 					mPreCalc
 				)
 		


### PR DESCRIPTION
I added a pseudo random number generator (SplittableRandom) that gives reproducible results for multithreaded environments. With this feature, the Dinosaur output is now completely reproducible (given the same number of threads and seed). This does require Java >= 1.8, so if you want to keep supporting Java 1.6 I'll have to find a workaround.

I also removed some code from Bootstrap.scala that was never called and fixed some indentation.