### PR TITLE
Bump Graphs and Dinosaur version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>se.lth.immun</groupId>
   <artifactId>Dinosaur</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <inceptionYear>2015</inceptionYear>
   <properties>
     <scala.version>2.10.7</scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
     	<groupId>se.lth.immun</groupId>
     	<artifactId>Graphs</artifactId>
-    	<version>1.0.0</version>
+    	<version>1.0.1</version>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
Resolves maven central problem with Graphs dependency on non-existant Xml package version (https://github.com/fickludd/proteomicore/pull/19).